### PR TITLE
Fix: Update protocolVersion to 2025-03-26

### DIFF
--- a/src/mcp_cli_client.py
+++ b/src/mcp_cli_client.py
@@ -43,7 +43,7 @@ class MCPClient:
                 "id": "init",
                 "method": "initialize",
                 "params": {
-                    "protocolVersion": "2024-11-05",
+                    "protocolVersion": "2025-03-26",
                     "capabilities": {
                         "sampling": {}
                     },


### PR DESCRIPTION
Changed the protocolVersion in `src/mcp_cli_client.py` to `2025-03-26` to align with the latest specification.